### PR TITLE
Try runs with older compilers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
     uses: boostorg/boost-ci/.github/workflows/reusable.yml@master
     with:
       exclude_compiler: 'clang-3.5,clang-3.6,clang-3.7,clang-3.8,clang-3.9,clang-4.0,clang-5.0,clang-6.0,clang-7,
-                         clang-8,clang-9,clang-10,clang-11,clang-12,clang-13,clang-14,clang-15,clang-16,
-                         gcc-4.7,gcc-4.8,gcc-4.9,gcc-5,gcc-6,gcc-7,gcc-8,gcc-9,gcc-10,gcc-11,gcc-12'
+                         clang-8,clang-9,clang-10,clang-11,clang-12,
+                         gcc-4.7,gcc-4.8,gcc-4.9,gcc-5,gcc-6,gcc-7,gcc-8,gcc-9'
     # Example of customization:
     # with:
     #   enable_reflection: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
     uses: boostorg/boost-ci/.github/workflows/reusable.yml@master
     with:
       exclude_compiler: 'clang-3.5,clang-3.6,clang-3.7,clang-3.8,clang-3.9,clang-4.0,clang-5.0,clang-6.0,clang-7,
-                         clang-8,clang-9,clang-10,clang-11,clang-12,
-                         gcc-4.7,gcc-4.8,gcc-4.9,gcc-5,gcc-6,gcc-7,gcc-8,gcc-9'
+                         clang-8,clang-9,clang-10,
+                         gcc-4.7,gcc-4.8,gcc-4.9,gcc-5,gcc-6,gcc-7,gcc-8'
     # Example of customization:
     # with:
     #   enable_reflection: true

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A safe and fully featured replacement for C++ builtin numeric types.
 
 This library requires C++20 and is tested on the following platforms:
 
-* GCC 13 and later
-* Clang 17 and later
+* GCC 9 and later
+* Clang 11 and later
 * Visual Studio 2022 and later
 * Intel OneAPI DPC++

--- a/doc/modules/ROOT/pages/overview.adoc
+++ b/doc/modules/ROOT/pages/overview.adoc
@@ -30,8 +30,8 @@ Safety critical applications
 Boost.safe_numbers is tested natively on Ubuntu (x86_64, x86_32, s390x, aarch64, ARM32v7), macOS (x86_64, and Apple Silicon), and Windows (x86_64, x86_32, and ARM64);
 as well as emulated PPC64LE using QEMU with the following compilers:
 
-* GCC 13 and later
-* Clang 17 and later
+* GCC 9 and later
+* Clang 11 and later
 * Visual Studio 2022 (14.3) and later
 * Intel OneAPI DPC++ 2024.2 and later
 

--- a/include/boost/safe_numbers/detail/config.hpp
+++ b/include/boost/safe_numbers/detail/config.hpp
@@ -56,4 +56,15 @@
 #  define BOOST_SAFE_NUMBERS_UNREACHABLE std::abort()
 #endif
 
+namespace boost::safe_numbers::detail {
+
+// Workaround for static_assert(false, ...) in if constexpr branches.
+// Before C++23 (P2593R1), static_assert(false) is ill-formed even in
+// discarded branches. Making the condition depend on a template parameter
+// defers evaluation until instantiation.
+template <typename...>
+inline constexpr auto dependent_false {false};
+
+} // namespace boost::safe_numbers::detail
+
 #endif // BOOST_SAFENUMBERS_CONFIG_HPP

--- a/include/boost/safe_numbers/detail/type_traits.hpp
+++ b/include/boost/safe_numbers/detail/type_traits.hpp
@@ -53,7 +53,7 @@ struct underlying<unsigned_integer_basis<T>>
 } // namespace impl
 
 template <typename T>
-using underlying_type_t = impl::underlying<T>::type;
+using underlying_type_t = typename impl::underlying<T>::type;
 
 } // namespace boost::safe_numbers::detail
 

--- a/include/boost/safe_numbers/detail/unsigned_integer_basis.hpp
+++ b/include/boost/safe_numbers/detail/unsigned_integer_basis.hpp
@@ -47,7 +47,7 @@ public:
         requires std::is_same_v<T, bool>
     explicit constexpr unsigned_integer_basis(T) noexcept
     {
-        static_assert(false, "Construction from bool is not allowed");
+        static_assert(dependent_false<T>, "Construction from bool is not allowed");
     }
 
     template <unsigned_integral OtherBasis>
@@ -86,7 +86,7 @@ constexpr unsigned_integer_basis<BasisType>::operator OtherBasis() const noexcep
 {
     if constexpr (sizeof(OtherBasis) < sizeof(BasisType))
     {
-        static_assert(false, "Narrowing conversions are not allowed");
+        static_assert(dependent_false<OtherBasis>, "Narrowing conversions are not allowed");
     }
 
     return static_cast<OtherBasis>(basis_);
@@ -356,95 +356,95 @@ template <unsigned_integral BasisType>
 
 } // namespace boost::safe_numbers::detail
 
-#define BOOST_SAFE_NUMBERS_DEFINE_MIXED_UNSIGNED_INTEGER_OP(OP_NAME, OP_SYMBOL)                    \
-template <boost::safe_numbers::detail::unsigned_integral LHSBasis,                                 \
-          boost::safe_numbers::detail::unsigned_integral RHSBasis>                                 \
-    requires (!std::is_same_v<LHSBasis, RHSBasis>)                                                 \
-constexpr auto OP_SYMBOL(const boost::safe_numbers::detail::unsigned_integer_basis<LHSBasis>,      \
-                         const boost::safe_numbers::detail::unsigned_integer_basis<RHSBasis>)      \
-{                                                                                                  \
-    if constexpr (std::is_same_v<LHSBasis, std::uint8_t>)                                          \
-    {                                                                                              \
-        if constexpr (std::is_same_v<RHSBasis, std::uint16_t>)                                     \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u8 and u16");                \
-        }                                                                                          \
-        else if constexpr (std::is_same_v<RHSBasis, std::uint32_t>)                                \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u8 and u32");                \
-        }                                                                                          \
-        else if constexpr (std::is_same_v<RHSBasis, std::uint64_t>)                                \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u8 and u64");                \
-        }                                                                                          \
-        else                                                                                       \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u8 and unknown type");       \
-        }                                                                                          \
-    }                                                                                              \
-    else if constexpr (std::is_same_v<LHSBasis, std::uint16_t>)                                    \
-    {                                                                                              \
-        if constexpr (std::is_same_v<RHSBasis, std::uint8_t>)                                      \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u16 and u8");                \
-        }                                                                                          \
-        else if constexpr (std::is_same_v<RHSBasis, std::uint32_t>)                                \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u16 and u32");               \
-        }                                                                                          \
-        else if constexpr (std::is_same_v<RHSBasis, std::uint64_t>)                                \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u16 and u64");               \
-        }                                                                                          \
-        else                                                                                       \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u16 and unknown type");      \
-        }                                                                                          \
-    }                                                                                              \
-    else if constexpr (std::is_same_v<LHSBasis, std::uint32_t>)                                    \
-    {                                                                                              \
-        if constexpr (std::is_same_v<RHSBasis, std::uint8_t>)                                      \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u32 and u8");                \
-        }                                                                                          \
-        else if constexpr (std::is_same_v<RHSBasis, std::uint16_t>)                                \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u32 and u16");               \
-        }                                                                                          \
-        else if constexpr (std::is_same_v<RHSBasis, std::uint64_t>)                                \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u32 and u64");               \
-        }                                                                                          \
-        else                                                                                       \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u32 and unknown type");      \
-        }                                                                                          \
-    }                                                                                              \
-    else if constexpr (std::is_same_v<LHSBasis, std::uint64_t>)                                    \
-    {                                                                                              \
-        if constexpr (std::is_same_v<RHSBasis, std::uint8_t>)                                      \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u64 and u8");                \
-        }                                                                                          \
-        else if constexpr (std::is_same_v<RHSBasis, std::uint16_t>)                                \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u64 and u16");               \
-        }                                                                                          \
-        else if constexpr (std::is_same_v<RHSBasis, std::uint32_t>)                                \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u64 and u32");               \
-        }                                                                                          \
-        else                                                                                       \
-        {                                                                                          \
-            static_assert(false, "Can not perform " OP_NAME " between u64 and unknown type");      \
-        }                                                                                          \
-    }                                                                                              \
-    else                                                                                           \
-    {                                                                                              \
-        static_assert(false, "Can not perform " OP_NAME " on mixed width unsigned integer types"); \
-    }                                                                                              \
-                                                                                                   \
-    return boost::safe_numbers::detail::unsigned_integer_basis<LHSBasis>(0);                       \
+#define BOOST_SAFE_NUMBERS_DEFINE_MIXED_UNSIGNED_INTEGER_OP(OP_NAME, OP_SYMBOL)                                                                                  \
+template <boost::safe_numbers::detail::unsigned_integral LHSBasis,                                                                                              \
+          boost::safe_numbers::detail::unsigned_integral RHSBasis>                                                                                              \
+    requires (!std::is_same_v<LHSBasis, RHSBasis>)                                                                                                              \
+constexpr auto OP_SYMBOL(const boost::safe_numbers::detail::unsigned_integer_basis<LHSBasis>,                                                                   \
+                         const boost::safe_numbers::detail::unsigned_integer_basis<RHSBasis>)                                                                   \
+{                                                                                                                                                               \
+    if constexpr (std::is_same_v<LHSBasis, std::uint8_t>)                                                                                                       \
+    {                                                                                                                                                           \
+        if constexpr (std::is_same_v<RHSBasis, std::uint16_t>)                                                                                                  \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u8 and u16");                  \
+        }                                                                                                                                                       \
+        else if constexpr (std::is_same_v<RHSBasis, std::uint32_t>)                                                                                             \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u8 and u32");                  \
+        }                                                                                                                                                       \
+        else if constexpr (std::is_same_v<RHSBasis, std::uint64_t>)                                                                                             \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u8 and u64");                  \
+        }                                                                                                                                                       \
+        else                                                                                                                                                    \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u8 and unknown type");         \
+        }                                                                                                                                                       \
+    }                                                                                                                                                           \
+    else if constexpr (std::is_same_v<LHSBasis, std::uint16_t>)                                                                                                 \
+    {                                                                                                                                                           \
+        if constexpr (std::is_same_v<RHSBasis, std::uint8_t>)                                                                                                   \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u16 and u8");                  \
+        }                                                                                                                                                       \
+        else if constexpr (std::is_same_v<RHSBasis, std::uint32_t>)                                                                                             \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u16 and u32");                 \
+        }                                                                                                                                                       \
+        else if constexpr (std::is_same_v<RHSBasis, std::uint64_t>)                                                                                             \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u16 and u64");                 \
+        }                                                                                                                                                       \
+        else                                                                                                                                                    \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u16 and unknown type");        \
+        }                                                                                                                                                       \
+    }                                                                                                                                                           \
+    else if constexpr (std::is_same_v<LHSBasis, std::uint32_t>)                                                                                                 \
+    {                                                                                                                                                           \
+        if constexpr (std::is_same_v<RHSBasis, std::uint8_t>)                                                                                                   \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u32 and u8");                  \
+        }                                                                                                                                                       \
+        else if constexpr (std::is_same_v<RHSBasis, std::uint16_t>)                                                                                             \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u32 and u16");                 \
+        }                                                                                                                                                       \
+        else if constexpr (std::is_same_v<RHSBasis, std::uint64_t>)                                                                                             \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u32 and u64");                 \
+        }                                                                                                                                                       \
+        else                                                                                                                                                    \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u32 and unknown type");        \
+        }                                                                                                                                                       \
+    }                                                                                                                                                           \
+    else if constexpr (std::is_same_v<LHSBasis, std::uint64_t>)                                                                                                 \
+    {                                                                                                                                                           \
+        if constexpr (std::is_same_v<RHSBasis, std::uint8_t>)                                                                                                   \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u64 and u8");                  \
+        }                                                                                                                                                       \
+        else if constexpr (std::is_same_v<RHSBasis, std::uint16_t>)                                                                                             \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u64 and u16");                 \
+        }                                                                                                                                                       \
+        else if constexpr (std::is_same_v<RHSBasis, std::uint32_t>)                                                                                             \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u64 and u32");                 \
+        }                                                                                                                                                       \
+        else                                                                                                                                                    \
+        {                                                                                                                                                       \
+            static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " between u64 and unknown type");        \
+        }                                                                                                                                                       \
+    }                                                                                                                                                           \
+    else                                                                                                                                                        \
+    {                                                                                                                                                           \
+        static_assert(boost::safe_numbers::detail::dependent_false<LHSBasis, RHSBasis>, "Can not perform " OP_NAME " on mixed width unsigned integer types");   \
+    }                                                                                                                                                           \
+                                                                                                                                                                \
+    return boost::safe_numbers::detail::unsigned_integer_basis<LHSBasis>(0);                                                                                    \
 }
 
 namespace boost::safe_numbers::detail {

--- a/include/boost/safe_numbers/format.hpp
+++ b/include/boost/safe_numbers/format.hpp
@@ -9,6 +9,8 @@
 #include <boost/safe_numbers/detail/int128/format.hpp>
 #include <boost/safe_numbers/detail/concepts.hpp>
 
+#ifdef BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_FORMAT
+
 #ifndef BOOST_SAFE_NUMBERS_BUILD_MODULE
 
 #include <format>
@@ -26,5 +28,7 @@ struct std::formatter<boost::safe_numbers::detail::unsigned_integer_basis<BasisT
         return std::formatter<BasisType>::format(static_cast<BasisType>(val), ctx);
     }
 };
+
+#endif // Has format
 
 #endif // BOOST_SAFE_NUMBERS_FORMAT_HPP

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -44,7 +44,7 @@ project : requirements
     <toolset>clang:<warnings-as-errors>on
     <toolset>gcc:<warnings-as-errors>on
 
-  [ requires cxx17_hdr_charconv cxx20_hdr_bit cxx20_hdr_compare cxx20_hdr_concepts cxx20_hdr_format ]
+  [ requires cxx20_hdr_bit cxx20_hdr_compare cxx20_hdr_concepts ]
   ;
 
 run quick.cpp ;

--- a/test/test_unsigned_std_format.cpp
+++ b/test/test_unsigned_std_format.cpp
@@ -9,9 +9,16 @@ import boost.safe_numbers;
 #else
 
 #include <boost/safe_numbers.hpp>
+
+#ifdef BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_FORMAT
+
 #include <format>
 
 #endif
+
+#endif
+
+#ifdef BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_FORMAT
 
 #include <boost/core/lightweight_test.hpp>
 
@@ -37,3 +44,12 @@ int main()
 
     return boost::report_errors();
 }
+
+#else
+
+int main()
+{
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
Guard support for `<format>`. Since we have switched to using boost.charconv instead of <charconv> the barrier should be much lower for full support