### PR TITLE
Move the `to_chars` and `from_chars` overloads into the `boost::charconv` namespace

### DIFF
--- a/doc/modules/ROOT/nav.adoc
+++ b/doc/modules/ROOT/nav.adoc
@@ -20,6 +20,7 @@
 ** xref:examples.adoc#examples_verified_compile_fail[Verified Types: Compile-Time Overflow]
 * xref:pretty_printers.adoc[]
 * xref:api_reference.adoc[]
+** xref:api_reference.adoc#api_namespaces[Namespaces]
 ** xref:api_reference.adoc#api_types[Types]
 ** xref:api_reference.adoc#api_functions[Functions]
 ** xref:api_reference.adoc#api_headers[Headers]

--- a/doc/modules/ROOT/pages/api_reference.adoc
+++ b/doc/modules/ROOT/pages/api_reference.adoc
@@ -8,6 +8,16 @@ https://www.boost.org/LICENSE_1_0.txt
 = API Reference
 :idprefix: api_ref_
 
+[#api_namespaces]
+== Namespaces
+
+[cols="1,2", options="header"]
+|===
+| Name | Description
+| `boost::charconv` | `to_chars` and `from_chars` overloads
+| `boost::safe_numbers` | All other parts of the library
+|===
+
 [#api_types]
 == Types
 

--- a/doc/modules/ROOT/pages/charconv.adoc
+++ b/doc/modules/ROOT/pages/charconv.adoc
@@ -29,21 +29,21 @@ This will disable auto-linking for Boost.Charconv.
 ----
 #include <boost/safe_numbers/charconv.hpp>
 
-namespace boost::safe_numbers {
+namespace boost::charconv {
 
 // Convert safe integer to character string
-template <detail::library_type T>
+template <safe_numbers::detail::library_type T>
 constexpr auto to_chars(char* first, char* last,
                         T value,
                         int base = 10) -> charconv::to_chars_result;
 
 // Convert character string to safe integer
-template <detail::library_type T>
+template <safe_numbers::detail::library_type T>
 constexpr auto from_chars(const char* first, const char* last,
                           T& value,
                           int base = 10) -> charconv::from_chars_result;
 
-} // namespace boost::safe_numbers
+} // namespace boost::charconv
 ----
 
 == to_chars_result
@@ -102,7 +102,7 @@ struct from_chars_result
 
 [source,c++]
 ----
-template <detail::library_type T>
+template <safe_numbers::detail::library_type T>
 constexpr auto to_chars(char* first, char* last,
                         T value,
                         int base = 10) -> charconv::to_chars_result;
@@ -132,7 +132,7 @@ Returns `boost::charconv::to_chars_result` with:
 
 [source,c++]
 ----
-template <detail::library_type T>
+template <safe_numbers::detail::library_type T>
 constexpr auto from_chars(const char* first, const char* last,
                           T& value,
                           int base = 10) -> charconv::from_chars_result;
@@ -168,14 +168,14 @@ The two overloads are distinguished via a `requires` clause:
 [source,c++]
 ----
 // Runtime overload (non-verified types)
-template <detail::library_type T>
-    requires (!detail::is_verified_type_v<T>)
+template <safe_numbers::detail::library_type T>
+    requires (!safe_numbers::detail::is_verified_type_v<T>)
 constexpr auto from_chars(const char* first, const char* last,
                           T& value, int base = 10) -> charconv::from_chars_result;
 
 // Compile-time overload (verified types only)
-template <detail::library_type T>
-    requires detail::is_verified_type_v<T>
+template <safe_numbers::detail::library_type T>
+    requires safe_numbers::detail::is_verified_type_v<T>
 consteval auto from_chars(const char* first, const char* last,
                           T& value, int base = 10) -> charconv::from_chars_result;
 ----

--- a/examples/charconv.cpp
+++ b/examples/charconv.cpp
@@ -11,6 +11,8 @@
 int main()
 {
     using namespace boost::safe_numbers;
+    using boost::charconv::to_chars;
+    using boost::charconv::from_chars;
 
     // to_chars: Convert safe integer to string
     u32 value {12345};

--- a/examples/verified_runtime_usage.cpp
+++ b/examples/verified_runtime_usage.cpp
@@ -51,14 +51,14 @@ int main()
     // Writing to a character buffer works at runtime since it only
     // reads the value through the constexpr conversion operator
     char buffer[32];
-    auto result = to_chars(buffer, buffer + sizeof(buffer), val);
+    auto result = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), val);
     if (result)
     {
         *result.ptr = '\0';
         std::cout << "to_chars (base 10): " << buffer << '\n';
     }
 
-    result = to_chars(buffer, buffer + sizeof(buffer), val, 16);
+    result = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), val, 16);
     if (result)
     {
         *result.ptr = '\0';

--- a/include/boost/safe_numbers/charconv.hpp
+++ b/include/boost/safe_numbers/charconv.hpp
@@ -14,14 +14,14 @@
 
 #endif // BOOST_SAFE_NUMBERS_BUILD_MODULE
 
-namespace boost::safe_numbers {
+namespace boost::charconv {
 
-template <detail::library_type T>
-    requires (!detail::is_verified_type_v<T>)
+template <safe_numbers::detail::library_type T>
+    requires (!safe_numbers::detail::is_verified_type_v<T>)
 constexpr auto from_chars(const char* first, const char* last, T& value, int base = 10)
     -> charconv::from_chars_result
 {
-    using underlying_type = detail::underlying_type_t<T>;
+    using underlying_type = safe_numbers::detail::underlying_type_t<T>;
 
     underlying_type result {};
     const auto r {charconv::from_chars(first, last, result, base)};
@@ -30,12 +30,12 @@ constexpr auto from_chars(const char* first, const char* last, T& value, int bas
     return r;
 }
 
-template <detail::library_type T>
-    requires detail::is_verified_type_v<T>
+template <safe_numbers::detail::library_type T>
+    requires safe_numbers::detail::is_verified_type_v<T>
 consteval auto from_chars(const char* first, const char* last, T& value, int base = 10)
     -> charconv::from_chars_result
 {
-    using underlying_type = detail::underlying_type_t<T>;
+    using underlying_type = safe_numbers::detail::underlying_type_t<T>;
 
     underlying_type result {};
     const auto r {charconv::from_chars(first, last, result, base)};
@@ -44,14 +44,14 @@ consteval auto from_chars(const char* first, const char* last, T& value, int bas
     return r;
 }
 
-template <detail::library_type T>
+template <safe_numbers::detail::library_type T>
 constexpr auto to_chars(char* first, char* last, const T value, int base = 10)
     -> charconv::to_chars_result
 {
-    using underlying_type = detail::underlying_type_t<T>;
+    using underlying_type = safe_numbers::detail::underlying_type_t<T>;
     return charconv::to_chars(first, last, static_cast<underlying_type>(value), base);
 }
 
-} // namespace boost::safe_numbers
+} // namespace boost::charconv
 
 #endif // BOOST_SAFE_NUMBERS_CHARCONV_HPP

--- a/test/test_unsigned_bounded_charconv.cpp
+++ b/test/test_unsigned_bounded_charconv.cpp
@@ -77,6 +77,8 @@ import boost.safe_numbers;
 #endif
 
 using namespace boost::safe_numbers;
+using boost::charconv::to_chars;
+using boost::charconv::from_chars;
 
 static std::mt19937_64 rng {42};
 

--- a/test/test_unsigned_charconv.cpp
+++ b/test/test_unsigned_charconv.cpp
@@ -77,6 +77,8 @@ import boost.safe_numbers;
 #endif
 
 using namespace boost::safe_numbers;
+using boost::charconv::to_chars;
+using boost::charconv::from_chars;
 
 static std::mt19937_64 rng {42};
 

--- a/test/test_verified_charconv.cpp
+++ b/test/test_verified_charconv.cpp
@@ -28,7 +28,7 @@ void test_to_chars()
     constexpr auto val = VerifiedT{BasisT{42}};
 
     char buffer[256];
-    const auto r = boost::safe_numbers::to_chars(buffer, buffer + sizeof(buffer), val);
+    const auto r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), val);
     BOOST_TEST(r.ec == std::errc{});
 
     const auto len = static_cast<std::size_t>(r.ptr - buffer);
@@ -43,7 +43,7 @@ void test_to_chars_zero()
     constexpr auto val = VerifiedT{BasisT{0}};
 
     char buffer[256];
-    const auto r = boost::safe_numbers::to_chars(buffer, buffer + sizeof(buffer), val);
+    const auto r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), val);
     BOOST_TEST(r.ec == std::errc{});
 
     const auto len = static_cast<std::size_t>(r.ptr - buffer);
@@ -57,7 +57,7 @@ void test_to_chars_255()
     constexpr auto val = VerifiedT{BasisT{255}};
 
     char buffer[256];
-    const auto r = boost::safe_numbers::to_chars(buffer, buffer + sizeof(buffer), val);
+    const auto r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), val);
     BOOST_TEST(r.ec == std::errc{});
 
     const auto len = static_cast<std::size_t>(r.ptr - buffer);
@@ -73,7 +73,7 @@ void test_to_chars_hex()
     constexpr auto val = VerifiedT{BasisT{255}};
 
     char buffer[256];
-    const auto r = boost::safe_numbers::to_chars(buffer, buffer + sizeof(buffer), val, 16);
+    const auto r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), val, 16);
     BOOST_TEST(r.ec == std::errc{});
 
     const auto len = static_cast<std::size_t>(r.ptr - buffer);
@@ -91,7 +91,7 @@ consteval auto test_from_chars_impl() -> bool
 {
     const char str[] = "42";
     auto val = VerifiedT{BasisT{0}};
-    const auto r = boost::safe_numbers::from_chars(str, str + 2, val);
+    const auto r = boost::charconv::from_chars(str, str + 2, val);
     return r.ec == std::errc{} && val == VerifiedT{BasisT{42}};
 }
 
@@ -100,7 +100,7 @@ consteval auto test_from_chars_zero_impl() -> bool
 {
     const char str[] = "0";
     auto val = VerifiedT{BasisT{1}};
-    const auto r = boost::safe_numbers::from_chars(str, str + 1, val);
+    const auto r = boost::charconv::from_chars(str, str + 1, val);
     return r.ec == std::errc{} && val == VerifiedT{BasisT{0}};
 }
 
@@ -109,7 +109,7 @@ consteval auto test_from_chars_255_impl() -> bool
 {
     const char str[] = "255";
     auto val = VerifiedT{BasisT{0}};
-    const auto r = boost::safe_numbers::from_chars(str, str + 3, val);
+    const auto r = boost::charconv::from_chars(str, str + 3, val);
     return r.ec == std::errc{} && val == VerifiedT{BasisT{255}};
 }
 
@@ -118,7 +118,7 @@ consteval auto test_from_chars_hex_impl() -> bool
 {
     const char str[] = "ff";
     auto val = VerifiedT{BasisT{0}};
-    const auto r = boost::safe_numbers::from_chars(str, str + 2, val, 16);
+    const auto r = boost::charconv::from_chars(str, str + 2, val, 16);
     return r.ec == std::errc{} && val == VerifiedT{BasisT{255}};
 }
 


### PR DESCRIPTION
Closes: #76 