### PR TITLE
Improve 128-bit mul performance

### DIFF
--- a/include/boost/safe_numbers/detail/signed_integer_basis.hpp
+++ b/include/boost/safe_numbers/detail/signed_integer_basis.hpp
@@ -1476,6 +1476,24 @@ auto signed_intrin_mul(const T lhs, const T rhs, T& result) -> signed_overflow_s
     return signed_overflow_status::no_error;
 }
 
+#ifdef BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128
+
+inline auto signed_intrin_mul(const int128::int128_t lhs, const int128::int128_t rhs, int128::int128_t& result) -> signed_overflow_status
+{
+    __int128_t builtin_result;
+    const auto overflow {__builtin_mul_overflow(static_cast<__int128_t>(lhs), static_cast<__int128_t>(rhs), &builtin_result)};
+    result = builtin_result;
+
+    if (overflow)
+    {
+        return (lhs >= 0) == (rhs >= 0) ? signed_overflow_status::overflow : signed_overflow_status::underflow;
+    }
+
+    return signed_overflow_status::no_error;
+}
+
+#endif // BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128
+
 #elif defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN)
 
 template <std::signed_integral T>
@@ -1765,7 +1783,10 @@ struct signed_mul_helper
 
         #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN)
 
+        // We have a 128-bit intrin path, but only with __builtin_mul_overflow
+        #if defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN) || !defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128)
         if constexpr (!std::is_same_v<BasisType, int128::int128_t>)
+        #endif
         {
             #if !(defined(__CUDACC__) && defined(BOOST_SAFE_NUMBERS_ENABLE_CUDA))
 
@@ -1812,7 +1833,10 @@ struct signed_mul_helper<overflow_policy::overflow_tuple, BasisType>
 
         #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN)
 
+        // We have a 128-bit intrin path, but only with __builtin_mul_overflow
+        #if defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN) || !defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128)
         if constexpr (!std::is_same_v<BasisType, int128::int128_t>)
+        #endif
         {
             #if !(defined(__CUDACC__) && defined(BOOST_SAFE_NUMBERS_ENABLE_CUDA))
 
@@ -1849,7 +1873,10 @@ struct signed_mul_helper<overflow_policy::checked, BasisType>
 
         #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN)
 
+        // We have a 128-bit intrin path, but only with __builtin_mul_overflow
+        #if defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN) || !defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128)
         if constexpr (!std::is_same_v<BasisType, int128::int128_t>)
+        #endif
         {
             #if !(defined(__CUDACC__) && defined(BOOST_SAFE_NUMBERS_ENABLE_CUDA))
 

--- a/include/boost/safe_numbers/detail/signed_integer_basis.hpp
+++ b/include/boost/safe_numbers/detail/signed_integer_basis.hpp
@@ -1462,6 +1462,10 @@ BOOST_SAFE_NUMBERS_HOST_DEVICE constexpr auto signed_underflow_mul_msg() noexcep
         return "Underflow detected in i128 multiplication";
     }
 }
+
+// clang lowers signed __builtin_mul_overflow on __int128 to __muloti4 (compiler-rt
+// only), which is missing when linking libgcc on clang-13. Limit the fast path to
+// GCC and clang >= 14; everything else uses signed_no_intrin_mul for int128.
 #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) && defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128) && (!defined(__clang__) || __clang_major__ >= 14)
 #  define BOOST_SAFE_NUMBERS_HAS_INT128_SIGNED_INTRIN_MUL
 #endif
@@ -1786,8 +1790,9 @@ struct signed_mul_helper
 
         #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN)
 
-        // We have a 128-bit intrin path, but only with __builtin_mul_overflow
-        #if defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN) || !defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128)
+        // Route int128 through the intrin path only where the signed 128-bit
+        // fast path links (GCC, clang >= 14); elsewhere it uses no_intrin.
+        #if !defined(BOOST_SAFE_NUMBERS_HAS_INT128_SIGNED_INTRIN_MUL)
         if constexpr (!std::is_same_v<BasisType, int128::int128_t>)
         #endif
         {
@@ -1836,8 +1841,9 @@ struct signed_mul_helper<overflow_policy::overflow_tuple, BasisType>
 
         #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN)
 
-        // We have a 128-bit intrin path, but only with __builtin_mul_overflow
-        #if defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN) || !defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128)
+        // Route int128 through the intrin path only where the signed 128-bit
+        // fast path links (GCC, clang >= 14); elsewhere it uses no_intrin.
+        #if !defined(BOOST_SAFE_NUMBERS_HAS_INT128_SIGNED_INTRIN_MUL)
         if constexpr (!std::is_same_v<BasisType, int128::int128_t>)
         #endif
         {
@@ -1876,8 +1882,9 @@ struct signed_mul_helper<overflow_policy::checked, BasisType>
 
         #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN)
 
-        // We have a 128-bit intrin path, but only with __builtin_mul_overflow
-        #if defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN) || !defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128)
+        // Route int128 through the intrin path only where the signed 128-bit
+        // fast path links (GCC, clang >= 14); elsewhere it uses no_intrin.
+        #if !defined(BOOST_SAFE_NUMBERS_HAS_INT128_SIGNED_INTRIN_MUL)
         if constexpr (!std::is_same_v<BasisType, int128::int128_t>)
         #endif
         {

--- a/include/boost/safe_numbers/detail/signed_integer_basis.hpp
+++ b/include/boost/safe_numbers/detail/signed_integer_basis.hpp
@@ -1462,6 +1462,9 @@ BOOST_SAFE_NUMBERS_HOST_DEVICE constexpr auto signed_underflow_mul_msg() noexcep
         return "Underflow detected in i128 multiplication";
     }
 }
+#if BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) && defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128) && (!defined(__clang__) || __clang_major__ >= 14)
+#  define BOOST_SAFE_NUMBERS_HAS_INT128_SIGNED_INTRIN_MUL
+#endif
 
 #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow)
 
@@ -1476,7 +1479,7 @@ auto signed_intrin_mul(const T lhs, const T rhs, T& result) -> signed_overflow_s
     return signed_overflow_status::no_error;
 }
 
-#ifdef BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128
+#ifdef BOOST_SAFE_NUMBERS_HAS_INT128_SIGNED_INTRIN_MUL
 
 inline auto signed_intrin_mul(const int128::int128_t lhs, const int128::int128_t rhs, int128::int128_t& result) -> signed_overflow_status
 {
@@ -1492,7 +1495,7 @@ inline auto signed_intrin_mul(const int128::int128_t lhs, const int128::int128_t
     return signed_overflow_status::no_error;
 }
 
-#endif // BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128
+#endif // BOOST_SAFE_NUMBERS_HAS_INT128_SIGNED_INTRIN_MUL
 
 #elif defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) || defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X86_INTRIN)
 

--- a/include/boost/safe_numbers/detail/unsigned_integer_basis.hpp
+++ b/include/boost/safe_numbers/detail/unsigned_integer_basis.hpp
@@ -1252,6 +1252,18 @@ bool unsigned_intrin_mul(const T lhs, const T rhs, T& result)
     return __builtin_mul_overflow(lhs, rhs, &result);
 }
 
+#ifdef BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128
+
+inline bool unsigned_intrin_mul(const int128::uint128_t lhs, const int128::uint128_t rhs, int128::uint128_t& result)
+{
+    __uint128_t builtin_result;
+    const auto overflow {__builtin_mul_overflow(static_cast<__uint128_t>(lhs), static_cast<__uint128_t>(rhs), &builtin_result)};
+    result = builtin_result;
+    return overflow;
+}
+
+#endif
+
 #elif defined(BOOST_SAFENUMBERS_HAS_WINDOWS_X64_INTRIN) && !(defined(__CUDACC__) && defined(BOOST_SAFE_NUMBERS_ENABLE_CUDA))
 
 template <std::unsigned_integral T>
@@ -1390,7 +1402,10 @@ struct mul_helper
             }
         };
 
+        // We have an intrin path, but only with __builtin_mul_overflow
+        #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(_umul128) || !defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128)
         if constexpr (!std::is_same_v<BasisType, int128::uint128_t>)
+        #endif
         {
             #if (BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) || BOOST_SAFE_NUMBERS_HAS_BUILTIN(_umul128)) && !(defined(__CUDACC__) && defined(BOOST_SAFE_NUMBERS_ENABLE_CUDA))
 

--- a/include/boost/safe_numbers/detail/unsigned_integer_basis.hpp
+++ b/include/boost/safe_numbers/detail/unsigned_integer_basis.hpp
@@ -1446,7 +1446,10 @@ struct mul_helper<overflow_policy::overflow_tuple, BasisType>
         const auto rhs_basis {static_cast<BasisType>(rhs)};
         BasisType res {};
 
+        // We have an intrin path, but only with __builtin_mul_overflow
+        #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(_umul128) || !defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128)
         if constexpr (!std::is_same_v<BasisType, int128::uint128_t>)
+        #endif
         {
             #if (BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) || BOOST_SAFE_NUMBERS_HAS_BUILTIN(_umul128)) && !(defined(__CUDACC__) && defined(BOOST_SAFE_NUMBERS_ENABLE_CUDA))
 
@@ -1479,7 +1482,10 @@ struct mul_helper<overflow_policy::checked, BasisType>
         const auto rhs_basis {static_cast<BasisType>(rhs)};
         BasisType res {};
 
+        // We have an intrin path, but only with __builtin_mul_overflow
+        #if BOOST_SAFE_NUMBERS_HAS_BUILTIN(_umul128) || !defined(BOOST_SAFE_NUMBERS_DETAIL_INT128_HAS_INT128)
         if constexpr (!std::is_same_v<BasisType, int128::uint128_t>)
+        #endif
         {
             #if (BOOST_SAFE_NUMBERS_HAS_BUILTIN(__builtin_mul_overflow) || BOOST_SAFE_NUMBERS_HAS_BUILTIN(_umul128)) && !(defined(__CUDACC__) && defined(BOOST_SAFE_NUMBERS_ENABLE_CUDA))
 

--- a/test/benchmarks/benchmark_float_operations.cpp
+++ b/test/benchmarks/benchmark_float_operations.cpp
@@ -120,6 +120,18 @@ auto benchmark_subtraction(const std::vector<T>& values, const char* type)
     return benchmark_op(values, std::minus<>(), type, "sub");
 }
 
+template <typename T>
+auto benchmark_multiplication(const std::vector<T>& values, const char* type)
+{
+    return benchmark_op(values, std::multiplies<>(), type, "mul");
+}
+
+template <typename T>
+auto benchmark_division(const std::vector<T>& values, const char* type)
+{
+    return benchmark_op(values, std::divides<>(), type, "div");
+}
+
 #ifdef _MSC_VER
 #pragma optimize("", on)
 #endif
@@ -148,6 +160,14 @@ int main()
         builtin_runtime = benchmark_subtraction(builtin_values, "float");
         lib_runtime = benchmark_subtraction(lib_values, "boost::sn::f32");
         print_runtime_ratio(lib_runtime, builtin_runtime);
+
+        builtin_runtime = benchmark_multiplication(builtin_values, "float");
+        lib_runtime = benchmark_multiplication(lib_values, "boost::sn::f32");
+        print_runtime_ratio(lib_runtime, builtin_runtime);
+
+        builtin_runtime = benchmark_division(builtin_values, "float");
+        lib_runtime = benchmark_division(lib_values, "boost::sn::f32");
+        print_runtime_ratio(lib_runtime, builtin_runtime);
     }
     {
         std::cout << "\n64-bit Floats\n";
@@ -160,6 +180,14 @@ int main()
 
         builtin_runtime = benchmark_subtraction(builtin_values, "double");
         lib_runtime = benchmark_subtraction(lib_values, "boost::sn::f64");
+        print_runtime_ratio(lib_runtime, builtin_runtime);
+
+        builtin_runtime = benchmark_multiplication(builtin_values, "double");
+        lib_runtime = benchmark_multiplication(lib_values, "boost::sn::f64");
+        print_runtime_ratio(lib_runtime, builtin_runtime);
+
+        builtin_runtime = benchmark_division(builtin_values, "double");
+        lib_runtime = benchmark_division(lib_values, "boost::sn::f64");
         print_runtime_ratio(lib_runtime, builtin_runtime);
     }
 


### PR DESCRIPTION
Was 2.5x the builtin, now it's roughly inline with each of the other types